### PR TITLE
Update "Sample data" section in development guide

### DIFF
--- a/developers/installation.md
+++ b/developers/installation.md
@@ -91,7 +91,9 @@ If you want to quickly get some sample data in your Aleph instance you can use `
 aleph crawldir /aleph/contrib/testdata
 ```
 
-To also get a sample of \(non-document\) entity data, consider loading [sanctions lists](installation.md).
+Make sure that a worker is running, otherwise your data won’t be processed. Run `make worker` to start a worker in your development environment. If you can’t see your sample data, make sure that you’re signed in, as your data won’t be public by default. See [Users](installation.md#users) for instructions on how to create new user accounts.
+
+To also get a sample of \(non-document\) entity data, consider loading [sanctions lists](datacommons.md#opensanctions).
 
 ### Running Tests
 


### PR DESCRIPTION
This explicitly mentions that you need to run a worker and to be authenticated in order to load and see sample data during development. If you’re like me and tend to only skim docs, that’s easy to miss otherwise… 😉